### PR TITLE
add SSL fallback with verify=False for enterprise proxy environments

### DIFF
--- a/osam/types/_blob.py
+++ b/osam/types/_blob.py
@@ -29,7 +29,28 @@ class Blob:
             return None
 
     def pull(self):
-        gdown.cached_download(url=self.url, path=self.path, hash=self.hash)
+        try:
+            return gdown.cached_download(
+                url=self.url,
+                path=self.path,
+                hash=self.hash,
+                use_cookies=False,
+                postprocess=None,
+                verify=True,
+            )
+        except Exception as e:
+            logger.warning(f"SSL verification failed: {e}")
+            logger.warning("Retrying with verify=False (enterprise proxy fallback)")
+
+            return gdown.cached_download(
+                url=self.url,
+                path=self.path,
+                hash=self.hash,
+                use_cookies=False,
+                postprocess=None,
+                verify=False,
+            )
+        
 
     def remove(self):
         if os.path.exists(self.path):


### PR DESCRIPTION
I updated the download logic in Blob.pull() to handle SSL verification issues that were preventing downloads from working in my company environment. With the new approach I try a secure download first and falling back to verify=False only if necessary, the code now works reliably for me, whereas the previous version failed.