### PR TITLE
feat!: update SAM3 to v0.3.0 and store masks cropped to bounding box

### DIFF
--- a/osam/__main__.py
+++ b/osam/__main__.py
@@ -175,8 +175,21 @@ def run(model_name: str, image_path: str, prompt, json: bool) -> None:
             )
 
         masks: NDArray[np.bool_] | None = None
-        if all(annotation.mask is not None for annotation in response.annotations):
-            masks = np.array([annotation.mask for annotation in response.annotations])
+        if all(
+            annotation.mask is not None and annotation.bounding_box is not None
+            for annotation in response.annotations
+        ):
+            h, w = image.shape[:2]
+            mask_list = []
+            for annotation in response.annotations:
+                full_mask = np.zeros((h, w), dtype=bool)
+                assert annotation.bounding_box is not None
+                bb = annotation.bounding_box
+                full_mask[
+                    bb.ymin : bb.ymax + 1, bb.xmin : bb.xmax + 1
+                ] = annotation.mask
+                mask_list.append(full_mask)
+            masks = np.array(mask_list)
 
         visualization = imgviz.instances2rgb(
             image=image,

--- a/osam/_models/sam/_models.py
+++ b/osam/_models/sam/_models.py
@@ -60,11 +60,14 @@ class SamBase(types.Model):
         bounding_box: types.BoundingBox = types.BoundingBox(
             ymin=bbox[0], xmin=bbox[1], ymax=bbox[2], xmax=bbox[3]
         )
+        cropped_mask = mask[bbox[0] : bbox[2] + 1, bbox[1] : bbox[3] + 1]
 
         return types.GenerateResponse(
             model=self.name,
             image_embedding=image_embedding,
-            annotations=[types.Annotation(mask=mask, bounding_box=bounding_box)],
+            annotations=[
+                types.Annotation(mask=cropped_mask, bounding_box=bounding_box)
+            ],
         )
 
 

--- a/osam/_models/sam3/_models.py
+++ b/osam/_models/sam3/_models.py
@@ -15,34 +15,28 @@ class Sam3(types.Model):
 
     _blobs = {
         "image_encoder": types.Blob(
-            url="https://huggingface.co/wkentaro/sam3-onnx-models/resolve/main/sam3_image_encoder.onnx",
-            hash="sha256:3dd676271e9c459463f7026d8ab2c6318672cd89511f89c30b34cdf0a2e67a3f",
+            url="https://huggingface.co/wkentaro/sam3-onnx-models-v0.3.0/resolve/main/sam3_image_encoder.onnx",
+            hash="sha256:c6f3769e9d42573806c34b663d6100b3827a4c0ecba6f45dbf39b8f3906be725",
             attachments=[
                 types.Blob(
-                    url="https://huggingface.co/wkentaro/sam3-onnx-models/resolve/main/sam3_image_encoder.onnx.data",
+                    url="https://huggingface.co/wkentaro/sam3-onnx-models-v0.3.0/resolve/main/sam3_image_encoder.onnx.data",
                     hash="sha256:03bd50b0703e2b04e2193ca831b7f9d5ecf40bc5287cc59b1970f56ab800c995",
                 ),
             ],
         ),
         "language_encoder": types.Blob(
-            url="https://huggingface.co/wkentaro/sam3-onnx-models/resolve/main/sam3_language_encoder.onnx",
-            hash="sha256:af80dffcd8fc369281b0422295244ba22f64e8424e9eefa111ac8966e9ea9ba6",
+            url="https://huggingface.co/wkentaro/sam3-onnx-models-v0.3.0/resolve/main/sam3_language_encoder.onnx",
+            hash="sha256:b3b465935c9bf4cf5efd950589741f3da5eec9e9bfe459576989cbe565331b53",
             attachments=[
                 types.Blob(
-                    url="https://huggingface.co/wkentaro/sam3-onnx-models/resolve/main/sam3_language_encoder.onnx.data",
+                    url="https://huggingface.co/wkentaro/sam3-onnx-models-v0.3.0/resolve/main/sam3_language_encoder.onnx.data",
                     hash="sha256:1b03dabc657c1f2887d1b8ce2a3537467d4c033ea1f8c8be141fbca55e4b95f7",
                 ),
             ],
         ),
         "decoder": types.Blob(
-            url="https://huggingface.co/wkentaro/sam3-onnx-models/resolve/main/sam3_decoder.onnx",
-            hash="sha256:aca3109a1bf87d1589bf2a4a61c641fd97624152b21c6e9a5aa85735db398884",
-            attachments=[
-                types.Blob(
-                    url="https://huggingface.co/wkentaro/sam3-onnx-models/resolve/main/sam3_decoder.onnx.data",
-                    hash="sha256:afae2f057f4c6e2478589877aa3d361a0d863cdfdb8259f7eee903f529188ac6",
-                ),
-            ],
+            url="https://huggingface.co/wkentaro/sam3-onnx-models-v0.3.0/resolve/main/sam3_decoder.onnx",
+            hash="sha256:bbc216dbf3de4742f692c2a0a0fd215ea8957956002a05f28150040a88b5dc1a",
         ),
     }
 
@@ -162,8 +156,6 @@ class Sam3(types.Model):
         outputs = self._inference_sessions["decoder"].run(
             None,
             {
-                "original_height": np.array(original_height, dtype=np.int64),
-                "original_width": np.array(original_width, dtype=np.int64),
                 "backbone_fpn_0": backbone_fpn_0,
                 "backbone_fpn_1": backbone_fpn_1,
                 "backbone_fpn_2": backbone_fpn_2,
@@ -175,24 +167,50 @@ class Sam3(types.Model):
                 "box_masks": box_masks,
             },
         )
-        boxes: NDArray[np.float32] = cast(NDArray[np.float32], outputs[0])
+        boxes_norm: NDArray[np.float32] = cast(NDArray[np.float32], outputs[0])
         scores: NDArray[np.float32] = cast(NDArray[np.float32], outputs[1])
-        masks: NDArray[np.bool_] = cast(NDArray[np.bool_], outputs[2])
+        masks_native: NDArray[np.float32] = cast(NDArray[np.float32], outputs[2])
+        mask_h, mask_w = masks_native.shape[2], masks_native.shape[3]
+
+        # Scale normalized boxes to original image coordinates
+        boxes = boxes_norm * np.array(
+            [original_width, original_height, original_width, original_height],
+            dtype=np.float32,
+        )
+        # Scale normalized boxes to native mask coordinates
+        boxes_mask = boxes_norm * np.array(
+            [mask_w, mask_h, mask_w, mask_h], dtype=np.float32
+        )
 
         annotations: list[types.Annotation] = []
         for i in range(len(scores)):
             if scores[i] < score_threshold:
                 continue
             box = boxes[i]
+            bb = types.BoundingBox(
+                xmin=round(box[0]),
+                ymin=round(box[1]),
+                xmax=round(box[2]),
+                ymax=round(box[3]),
+            )
+            bbox_w = bb.xmax - bb.xmin + 1
+            bbox_h = bb.ymax - bb.ymin + 1
+            # Crop in native mask space, then resize to bbox dimensions
+            bm = boxes_mask[i].astype(int)
+            native_crop = masks_native[i, 0, bm[1] : bm[3] + 1, bm[0] : bm[2] + 1]
+            cropped_mask: NDArray[np.bool_] = (
+                np.asarray(
+                    PIL.Image.fromarray(native_crop).resize(
+                        (bbox_w, bbox_h),
+                        resample=PIL.Image.Resampling.BILINEAR,
+                    )
+                )
+                > 0.5
+            )
             annotations.append(
                 types.Annotation(
-                    mask=masks[i, 0] > 0,
-                    bounding_box=types.BoundingBox(
-                        xmin=int(box[0]),
-                        ymin=int(box[1]),
-                        xmax=int(box[2]),
-                        ymax=int(box[3]),
-                    ),
+                    mask=cropped_mask,
+                    bounding_box=bb,
                     text=text_prompt,
                     score=float(scores[i]),
                 )

--- a/osam/apis_test.py
+++ b/osam/apis_test.py
@@ -37,8 +37,9 @@ def test_generate_point_to_mask(model: str) -> None:
     assert annotation.score is None
     assert annotation.mask is not None
     assert annotation.mask.dtype == bool
-    assert annotation.mask.shape == image.shape[:2]
     assert annotation.bounding_box is not None
+    bb = annotation.bounding_box
+    assert annotation.mask.shape == (bb.ymax - bb.ymin + 1, bb.xmax - bb.xmin + 1)
 
 
 @pytest.mark.parametrize(
@@ -65,7 +66,11 @@ def test_generate_text_to_bounding_box(model: str, has_mask: bool) -> None:
         if has_mask:
             assert annotation.mask is not None
             assert annotation.mask.dtype == bool
-            assert annotation.mask.shape == image.shape[:2]
+            bb = annotation.bounding_box
+            assert annotation.mask.shape == (
+                bb.ymax - bb.ymin + 1,
+                bb.xmax - bb.xmin + 1,
+            )
         else:
             assert annotation.mask is None
 
@@ -91,8 +96,9 @@ def test_generate_box_to_mask_sam2(model: str) -> None:
         assert annotation.score is None
         assert annotation.mask is not None
         assert annotation.mask.dtype == bool
-        assert annotation.mask.shape == image.shape[:2]
         assert annotation.bounding_box is not None
+        bb = annotation.bounding_box
+        assert annotation.mask.shape == (bb.ymax - bb.ymin + 1, bb.xmax - bb.xmin + 1)
 
 
 @pytest.mark.parametrize("model", ["sam3:latest"])
@@ -117,5 +123,6 @@ def test_generate_box_to_mask_sam3(model: str) -> None:
         assert annotation.score is not None
         assert annotation.mask is not None
         assert annotation.mask.dtype == bool
-        assert annotation.mask.shape == image.shape[:2]
         assert annotation.bounding_box is not None
+        bb = annotation.bounding_box
+        assert annotation.mask.shape == (bb.ymax - bb.ymin + 1, bb.xmax - bb.xmin + 1)

--- a/osam/types/_annotation.py
+++ b/osam/types/_annotation.py
@@ -23,6 +23,19 @@ class Annotation(pydantic.BaseModel):
             raise ValueError("mask must be boolean arrays")
         return mask
 
+    @pydantic.model_validator(mode="after")
+    def validate_mask_bbox_consistency(self) -> "Annotation":
+        if self.mask is not None:
+            if self.bounding_box is None:
+                raise ValueError("bounding_box is required when mask is provided")
+            bb = self.bounding_box
+            expected = (bb.ymax - bb.ymin + 1, bb.xmax - bb.xmin + 1)
+            if self.mask.shape != expected:
+                raise ValueError(
+                    f"mask shape {self.mask.shape} != expected bbox shape {expected}"
+                )
+        return self
+
     @pydantic.field_serializer("mask")
     def serialize_mask(self, mask: Optional[np.ndarray]) -> Optional[str]:
         if mask is None:


### PR DESCRIPTION
## Summary
- Update SAM3 ONNX models to v0.3.0 (new decoder outputs normalized boxes + native-resolution masks)
- All models (SAM, SAM2, SAM3) now store bbox-cropped masks instead of full-image masks
- Added `Annotation` validator enforcing mask shape matches bounding box dimensions
- Visualization in CLI reconstructs full masks at the rendering boundary

## Why
The v0.3.0 ONNX decoder no longer accepts `original_height`/`original_width` and outputs masks at model native resolution. Storing cropped masks reduces memory usage, especially for large images with small objects.

## Test plan
- [x] SAM point-to-mask tests pass (9/9 — efficientsam, sam, sam2 variants)
- [x] SAM2 box-to-mask test passes
- [x] SAM3 text-to-bbox+mask test (requires new model download)
- [x] `osam run sam3 --image examples/_images/dogs.jpg` visual check
- [x] `make lint` passes