### PR TITLE
fix: use os.path.join for Windows path compatibility

### DIFF
--- a/osam/types/_blob.py
+++ b/osam/types/_blob.py
@@ -21,13 +21,15 @@ class Blob:
 
     @property
     def path(self) -> str:
-        base = os.path.expanduser("~/.cache/osam/models/blobs")
+        base = os.path.expanduser(
+            os.path.join("~", ".cache", "osam", "models", "blobs")
+        )
         if self.attachments:
             # Windows can't use ':' for directory names
             safe_hash = self.hash.replace("sha256:", "sha256-")
-            return f"{base}/{safe_hash}/{self.filename}"
+            return os.path.join(base, safe_hash, self.filename)
         else:
-            return f"{base}/{self.hash}"
+            return os.path.join(base, self.hash)
 
     @property
     def size(self) -> int | None:


### PR DESCRIPTION
## Summary
- Replace f-string path construction with `os.path.join()` in `Blob.path` property
- Replace hardcoded `~/.cache/...` string with `os.path.join("~", ".cache", ...)` for `expanduser`

## Why
Forward-slash path separators (`/`) in f-strings don't produce valid paths on Windows. Using `os.path.join()` ensures correct separators on all platforms.

## Test plan
- [x] Code review — no security or quality issues
- [ ] Verify blob path resolution works on Windows
- [x] Verify no behavior change on Unix (identical output)