### PR TITLE
feat: add progress callback to Model.pull and Blob.pull

### DIFF
--- a/osam/types/_blob.py
+++ b/osam/types/_blob.py
@@ -4,6 +4,7 @@ import dataclasses
 import os
 import shutil
 import urllib.parse
+from collections.abc import Callable
 
 import gdown
 from loguru import logger
@@ -59,23 +60,56 @@ class Blob:
             latest = max(latest, os.stat(attachment_path).st_mtime)
         return latest
 
-    def pull(self):
+    def pull(
+        self,
+        progress: Callable[[str, int, int | None], None] | None = None,
+    ) -> None:
+        def _gdown_progress(
+            filename: str,
+        ) -> Callable[[int, int | None], None] | None:
+            if progress is None:
+                return None
+            return lambda bytes_so_far, bytes_total: progress(
+                filename, bytes_so_far, bytes_total
+            )
+
+        def _download(url: str, path: str, hash: str, filename: str) -> None:
+            gdown.cached_download(
+                url=url,
+                path=path,
+                hash=hash,
+                progress=_gdown_progress(filename),
+            )
+
         if self.attachments:
             blob_dir: str = os.path.dirname(self.path)
             if os.path.isfile(blob_dir):
                 logger.warning("Removing file {!r} to create blob directory", blob_dir)
                 os.remove(blob_dir)
             os.makedirs(blob_dir, exist_ok=True)
-            gdown.cached_download(url=self.url, path=self.path, hash=self.hash)
+            _download(
+                url=self.url,
+                path=self.path,
+                hash=self.hash,
+                filename=self.filename,
+            )
             for attachment in self.attachments:
                 attachment_path: str = os.path.join(
                     os.path.dirname(self.path), attachment.filename
                 )
-                gdown.cached_download(
-                    url=attachment.url, path=attachment_path, hash=attachment.hash
+                _download(
+                    url=attachment.url,
+                    path=attachment_path,
+                    hash=attachment.hash,
+                    filename=attachment.filename,
                 )
         else:
-            gdown.cached_download(url=self.url, path=self.path, hash=self.hash)
+            _download(
+                url=self.url,
+                path=self.path,
+                hash=self.hash,
+                filename=self.filename,
+            )
 
     def remove(self):
         if self.attachments:

--- a/osam/types/_model.py
+++ b/osam/types/_model.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import hashlib
+from collections.abc import Callable
 from typing import Dict
 from typing import Optional
 from typing import Sequence
@@ -28,9 +29,12 @@ class Model(abc.ABC):
         self._inference_sessions = _load_inference_sessions(blobs=self._blobs)
 
     @classmethod
-    def pull(cls):
+    def pull(
+        cls,
+        progress: Callable[[str, int, int | None], None] | None = None,
+    ) -> None:
         for blob in cls._blobs.values():
-            blob.pull()
+            blob.pull(progress=progress)
 
     @classmethod
     def remove(cls):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 dependencies = [
   "click",
-  "gdown>=5.2.1",
+  "gdown>=6.0.0",
   "imgviz>=2.0.0",
   "loguru",
   "onnxruntime>=1.23.2",

--- a/uv.lock
+++ b/uv.lock
@@ -508,17 +508,18 @@ wheels = [
 
 [[package]]
 name = "gdown"
-version = "5.2.1"
+version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "filelock" },
     { name = "requests", extra = ["socks"] },
     { name = "tqdm" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/cf/919a9fa16faf8e4572a24d941353edaf4d54e3ddcd048e6c1aeb8c7a9903/gdown-5.2.1.tar.gz", hash = "sha256:247c2ad1f579db5b66b54c04e6a871995fc8fd7021708b950b8ba7b32cf90323", size = 284743, upload-time = "2026-01-11T09:34:01.037Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/01/9e0280ba321f73295374765dc3c0b1e03058188a592a48a321376f9eb092/gdown-6.0.0.tar.gz", hash = "sha256:1f1f735a174ef3599fca95786aafac1219b9d85d4c729ccb95e674996c47fd44", size = 262729, upload-time = "2026-04-12T06:37:40.182Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/21/35dd0a0b7428bd67b12b358d7b4277f693493a3839b071d540a4c8357b78/gdown-5.2.1-py3-none-any.whl", hash = "sha256:391f0480d495fb87644d1a1ee3ddfeb2144e1de31408fbc74f7e3b3ba927052b", size = 18241, upload-time = "2026-01-11T09:34:02.637Z" },
+    { url = "https://files.pythonhosted.org/packages/91/fd/a382bb6684b1fdbe5cd19aa980a04a67f6c91efd0e1e627f93614fe2d24e/gdown-6.0.0-py3-none-any.whl", hash = "sha256:c82d39a6b09ed7778012515c2fa4ab4dc36d7789300cd0b16b87d3a3e4a09955", size = 18243, upload-time = "2026-04-12T06:37:38.209Z" },
 ]
 
 [[package]]
@@ -1303,7 +1304,7 @@ dev = [
 requires-dist = [
     { name = "click" },
     { name = "fastapi", marker = "extra == 'serve'" },
-    { name = "gdown", specifier = ">=5.2.1" },
+    { name = "gdown", specifier = ">=6.0.0" },
     { name = "imgviz", specifier = ">=2.0.0" },
     { name = "loguru" },
     { name = "onnxruntime", specifier = ">=1.23.2" },


### PR DESCRIPTION
## Summary
- Add an optional `progress` callback parameter to `Blob.pull()` and `Model.pull()`
- Callback signature: `(filename, bytes_so_far, bytes_total) -> None`
- Adapts the callback to gdown's `(bytes_so_far, bytes_total)` format, prepending the filename
- Extract `_download` helper to consolidate repeated `gdown.cached_download` calls
- Bump gdown to 6.0.0

## Why
Enable callers (e.g., GUI applications) to display download progress bars when pulling model blobs.

## Test plan
- [x] Code review passed (no CRITICAL/HIGH issues)
- [x] Verified `progress` callback signature matches `gdown.download`'s expected type
- [x] Manual test: pull a model with a progress callback and verify updates are received