### PR TITLE
fix: make standalone blob cache path Windows-safe

### DIFF
--- a/osam/types/_blob.py
+++ b/osam/types/_blob.py
@@ -25,12 +25,12 @@ class Blob:
         base = os.path.expanduser(
             os.path.join("~", ".cache", "osam", "models", "blobs")
         )
+        # Windows can't use ':' in file or directory names
+        safe_hash = self.hash.replace("sha256:", "sha256-")
         if self.attachments:
-            # Windows can't use ':' for directory names
-            safe_hash = self.hash.replace("sha256:", "sha256-")
             return os.path.join(base, safe_hash, self.filename)
         else:
-            return os.path.join(base, self.hash)
+            return os.path.join(base, safe_hash)
 
     @property
     def size(self) -> int | None:

--- a/osam/types/_blob_test.py
+++ b/osam/types/_blob_test.py
@@ -1,0 +1,27 @@
+import os
+
+from ._blob import Blob
+
+
+def test_path_standalone_has_no_colon() -> None:
+    blob = Blob(
+        url="https://example.com/model.onnx",
+        hash="sha256:4cacbb23c6903b1acf87f1d77ed806b840800c5fcd4ac8f650cbffed474b8896",
+    )
+    assert os.path.basename(blob.path) == (
+        "sha256-4cacbb23c6903b1acf87f1d77ed806b840800c5fcd4ac8f650cbffed474b8896"
+    )
+    assert ":" not in os.path.basename(blob.path)
+
+
+def test_path_with_attachments_has_no_colon() -> None:
+    blob = Blob(
+        url="https://example.com/model.onnx",
+        hash="sha256:4cacbb23c6903b1acf87f1d77ed806b840800c5fcd4ac8f650cbffed474b8896",
+        attachments=[Blob(url="https://example.com/config.json", hash="sha256:abc")],
+    )
+    blob_dir = os.path.basename(os.path.dirname(blob.path))
+    assert blob_dir == (
+        "sha256-4cacbb23c6903b1acf87f1d77ed806b840800c5fcd4ac8f650cbffed474b8896"
+    )
+    assert os.path.basename(blob.path) == "model.onnx"


### PR DESCRIPTION
## Summary

Standalone blobs (those without attachments) stored their cache file at `~/.cache/osam/models/blobs/sha256:<hash>`. On Windows, `:` is the NTFS alternate-data-stream separator and is not a valid filename character, so writing or reading the blob failed with `[Errno 2] No such file or directory`. This broke every model download on Windows for models without attachments (e.g. `efficientsam`, the YOLO-World text model).

The colon was already sanitized to `sha256-<hash>` for blobs *with* attachments. This applies the same sanitization to standalone blobs so the path is valid on every platform.

## Impact

The cache path changes on all platforms (`sha256:<hash>` -> `sha256-<hash>`), so existing standalone-blob caches are re-downloaded once. Attachment blob paths are unchanged.

## Test plan

- [x] `osam/types/_blob_test.py` asserts standalone and attachment blob paths contain no `:` in their basename / directory name
- [x] `uv run pytest osam/types/_blob_test.py` passes
- [x] `ruff format --check` and `ruff check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)