### PR TITLE
fix: format ValueError messages instead of passing args positionally

### DIFF
--- a/osam/_models/sam/_decoding.py
+++ b/osam/_models/sam/_decoding.py
@@ -16,7 +16,7 @@ def generate_mask_from_image_embedding(
     input_size: int,
 ) -> npt.NDArray[np.bool_]:
     if prompt.points is None or prompt.point_labels is None:
-        raise ValueError("Prompt must contain points and point_labels: %r" % prompt)
+        raise ValueError(f"Prompt must contain points and point_labels: {prompt!r}")
 
     onnx_coord: npt.NDArray[np.float32] = np.concatenate(
         [prompt.points, np.array([[0.0, 0.0]])], axis=0

--- a/osam/_models/sam/_models.py
+++ b/osam/_models/sam/_models.py
@@ -50,7 +50,7 @@ class SamBase(types.Model):
         del request
 
         if prompt.points is None or prompt.point_labels is None:
-            raise ValueError("Prompt must contain points and point_labels: %r", prompt)
+            raise ValueError(f"Prompt must contain points and point_labels: {prompt!r}")
 
         mask: npt.NDArray[np.bool_] = self._generate_mask_from_image_embedding(
             image_embedding=image_embedding, prompt=prompt

--- a/osam/_models/yoloworld/__init__.py
+++ b/osam/_models/yoloworld/__init__.py
@@ -24,7 +24,7 @@ class _YoloWorld(types.Model):
             prompt = request.prompt
 
         if prompt.texts is None:
-            raise ValueError("prompt.texts is required: prompt=%r", prompt)
+            raise ValueError(f"prompt.texts is required: prompt={prompt!r}")
         token = clip.tokenize(texts=prompt.texts + [" "])
         outputs = self._inference_sessions["textual"].run(None, {"input": token})
         text_features: NDArray[np.float32] = cast(NDArray[np.float32], outputs[0])
@@ -33,7 +33,7 @@ class _YoloWorld(types.Model):
         )
         #
         if request.image is None:
-            raise ValueError("request.image is required: request=%r", request)
+            raise ValueError(f"request.image is required: request={request!r}")
         transformed_image, original_image_hw, padding_hw = _transform_image(
             image=request.image, input_size=self._input_size
         )

--- a/osam/types/_image_embedding.py
+++ b/osam/types/_image_embedding.py
@@ -22,10 +22,12 @@ class ImageEmbedding(pydantic.BaseModel):
         if isinstance(embedding, list):
             embedding = np.array(embedding, dtype=np.float32)
         if embedding.ndim != 3:
-            raise ValueError("embedding must be of dimension 3, not %r", embedding.ndim)
+            raise ValueError(
+                f"embedding must be of dimension 3, not {embedding.ndim!r}"
+            )
         if embedding.dtype != np.float32:
             raise ValueError(
-                "embedding must be of type float, but got %r", embedding.dtype
+                f"embedding must be of type float, but got {embedding.dtype!r}"
             )
         return embedding
 
@@ -48,8 +50,7 @@ class ImageEmbedding(pydantic.BaseModel):
                 if {"data", "shape", "dtype"} != set(high_res_feature.keys()):
                     raise ValueError(
                         "extra_features must have keys {'data', 'shape', 'dtype'}, "
-                        "but got %r",
-                        set(high_res_feature.keys()),
+                        f"but got {set(high_res_feature.keys())!r}"
                     )
                 high_res_feature_ndarray = np.frombuffer(
                     base64.b64decode(high_res_feature["data"]),
@@ -58,20 +59,19 @@ class ImageEmbedding(pydantic.BaseModel):
             else:
                 raise ValueError(
                     "extra_features must be either a numpy array or a dictionary, "
-                    "but got %r",
-                    high_res_feature,
+                    f"but got {high_res_feature!r}"
                 )
             del high_res_feature
 
             if high_res_feature_ndarray.ndim != 3:
                 raise ValueError(
-                    "extra_features must be of dimension 3, not %r",
-                    high_res_feature_ndarray.ndim,
+                    "extra_features must be of dimension 3, not "
+                    f"{high_res_feature_ndarray.ndim!r}"
                 )
             if high_res_feature_ndarray.dtype != np.float32:
                 raise ValueError(
-                    "extra_features must be of type float, but got %r",
-                    high_res_feature_ndarray.dtype,
+                    "extra_features must be of type float, but got "
+                    f"{high_res_feature_ndarray.dtype!r}"
                 )
             extra_features_ndarray.append(high_res_feature_ndarray)
         return extra_features_ndarray

--- a/osam/types/_image_embedding_test.py
+++ b/osam/types/_image_embedding_test.py
@@ -1,0 +1,100 @@
+from typing import Any
+from typing import cast
+
+import numpy as np
+import numpy.typing as npt
+import pydantic
+import pytest
+
+from ._image_embedding import ImageEmbedding
+
+
+def test_validate_embedding_rejects_wrong_ndim() -> None:
+    with pytest.raises(pydantic.ValidationError) as excinfo:
+        ImageEmbedding(
+            original_height=1,
+            original_width=1,
+            embedding=np.zeros((2, 2), dtype=np.float32),
+        )
+    message = str(excinfo.value)
+    assert "embedding must be of dimension 3, not 2" in message
+    assert "%r" not in message
+
+
+def test_validate_embedding_rejects_wrong_dtype() -> None:
+    with pytest.raises(pydantic.ValidationError) as excinfo:
+        ImageEmbedding(
+            original_height=1,
+            original_width=1,
+            embedding=np.zeros((1, 1, 1), dtype=np.float64),
+        )
+    message = str(excinfo.value)
+    assert "embedding must be of type float" in message
+    assert "%r" not in message
+
+
+@pytest.fixture
+def embedding() -> npt.NDArray[np.float32]:
+    return np.zeros((1, 1, 1), dtype=np.float32)
+
+
+def test_validate_extra_features_rejects_non_array_non_dict(
+    embedding: npt.NDArray[np.float32],
+) -> None:
+    extra_features = cast(Any, ["not an array or dict"])
+    with pytest.raises(pydantic.ValidationError) as excinfo:
+        ImageEmbedding(
+            original_height=1,
+            original_width=1,
+            embedding=embedding,
+            extra_features=extra_features,
+        )
+    message = str(excinfo.value)
+    assert "extra_features must be either a numpy array or a dictionary" in message
+    assert "%r" not in message
+
+
+def test_validate_extra_features_rejects_dict_with_wrong_keys(
+    embedding: npt.NDArray[np.float32],
+) -> None:
+    extra_features = cast(Any, [{"data": "", "shape": []}])
+    with pytest.raises(pydantic.ValidationError) as excinfo:
+        ImageEmbedding(
+            original_height=1,
+            original_width=1,
+            embedding=embedding,
+            extra_features=extra_features,
+        )
+    message = str(excinfo.value)
+    assert "extra_features must have keys" in message
+    assert "%r" not in message
+
+
+def test_validate_extra_features_rejects_wrong_ndim(
+    embedding: npt.NDArray[np.float32],
+) -> None:
+    with pytest.raises(pydantic.ValidationError) as excinfo:
+        ImageEmbedding(
+            original_height=1,
+            original_width=1,
+            embedding=embedding,
+            extra_features=[np.zeros((2, 2), dtype=np.float32)],
+        )
+    message = str(excinfo.value)
+    assert "extra_features must be of dimension 3, not 2" in message
+    assert "%r" not in message
+
+
+def test_validate_extra_features_rejects_wrong_dtype(
+    embedding: npt.NDArray[np.float32],
+) -> None:
+    with pytest.raises(pydantic.ValidationError) as excinfo:
+        ImageEmbedding(
+            original_height=1,
+            original_width=1,
+            embedding=embedding,
+            extra_features=[np.zeros((1, 1, 1), dtype=np.float64)],
+        )
+    message = str(excinfo.value)
+    assert "extra_features must be of type float" in message
+    assert "%r" not in message


### PR DESCRIPTION
Several validators raised `ValueError("... %r", value)`, passing the value as a
second positional argument. `ValueError` does no `%`-interpolation, so it just
stored `(message, value)` as a 2-tuple in `args`. Surfaced through pydantic
validators, the error read as the garbled tuple
`('embedding must be of dimension 3, not %r', 2)` instead of
`embedding must be of dimension 3, not 2`.

This switches the affected raises in `types/_image_embedding.py`,
`_models/sam/_models.py`, and `_models/yoloworld/__init__.py` to f-strings, and
converts the one remaining `%`-operator message in `_models/sam/_decoding.py`
for consistency.

## Test plan
- [x] Added `types/_image_embedding_test.py` pinning the corrected validator
      messages (and asserting no literal `%r` leaks through)
- [x] `make lint` (ruff, ty)
- [x] `pytest osam/` — 24 passed
