### PR TITLE
test: add type annotations and tests for tabulate

### DIFF
--- a/osam/_tabulate.py
+++ b/osam/_tabulate.py
@@ -1,7 +1,7 @@
 import collections
 
 
-def tabulate(rows, headers):
+def tabulate(rows: list[list[str]], headers: list[str]) -> str:
     col_widths = collections.defaultdict(int)
     for row in [headers] + rows:
         for c, item in enumerate(row):

--- a/osam/_tabulate_test.py
+++ b/osam/_tabulate_test.py
@@ -1,0 +1,29 @@
+from ._tabulate import tabulate
+
+
+def test_tabulate_aligns_columns_across_rows() -> None:
+    table = tabulate(
+        rows=[["a", "v1"], ["ccc", "v2"]],
+        headers=["NAME", "ID"],
+    )
+    lines = table.split("\n")
+    assert len(lines) == 3
+    assert lines[0].index("ID") == lines[1].index("v1") == lines[2].index("v2")
+
+
+def test_tabulate_widens_column_to_longest_cell() -> None:
+    table = tabulate(
+        rows=[["a-very-long-name", "v1"], ["short", "v2"]],
+        headers=["NAME", "ID"],
+    )
+    lines = table.split("\n")
+    id_start = lines[0].index("ID")
+    assert id_start > len("a-very-long-name")
+    assert lines[1].index("v1") == id_start == lines[2].index("v2")
+
+
+def test_tabulate_with_only_headers_has_no_rows() -> None:
+    table = tabulate(rows=[], headers=["NAME", "ID"])
+    assert "\n" not in table
+    assert "NAME" in table
+    assert "ID" in table


### PR DESCRIPTION
`_tabulate.tabulate()` was the only formatting helper left untyped and untested.
Annotate its signature as `(list[list[str]], list[str]) -> str` to match the
project's typing standard, and add a co-located test file covering the behaviors
the CLI `list` command depends on.

## Test plan
- [x] `pytest osam/_tabulate_test.py` — column alignment across rows, column
      widening to the longest cell, and the headers-only case
- [x] `make lint` (ruff, ty)
