### PR TITLE
fix: guard None in Prompt point serializers and validators

### DIFF
--- a/osam/types/_prompt.py
+++ b/osam/types/_prompt.py
@@ -19,16 +19,28 @@ class Prompt(pydantic.BaseModel):
     max_annotations: Optional[int] = pydantic.Field(default=100)
 
     @pydantic.field_serializer("points")
-    def _serialize_points(self: "Prompt", points: np.ndarray) -> list[list[float]]:
+    def _serialize_points(
+        self: "Prompt", points: Optional[np.ndarray]
+    ) -> Optional[list[list[float]]]:
+        if points is None:
+            return None
         return points.tolist()
 
     @pydantic.field_serializer("point_labels")
-    def _serialize_point_labels(self: "Prompt", point_labels: np.ndarray) -> list[int]:
+    def _serialize_point_labels(
+        self: "Prompt", point_labels: Optional[np.ndarray]
+    ) -> Optional[list[int]]:
+        if point_labels is None:
+            return None
         return point_labels.tolist()
 
     @pydantic.field_validator("points", mode="before")
     @classmethod
-    def _validate_points(cls: Type, points: Union[list, np.ndarray]):
+    def _validate_points(
+        cls: Type, points: Optional[Union[list, np.ndarray]]
+    ) -> Optional[np.ndarray]:
+        if points is None:
+            return None
         if isinstance(points, list):
             points = np.array(points, dtype=float)
         if points.ndim != 2:
@@ -39,7 +51,11 @@ class Prompt(pydantic.BaseModel):
 
     @pydantic.field_validator("point_labels", mode="before")
     @classmethod
-    def _validate_point_labels(cls: Type, point_labels: Union[list, np.ndarray]):
+    def _validate_point_labels(
+        cls: Type, point_labels: Optional[Union[list, np.ndarray]]
+    ) -> Optional[np.ndarray]:
+        if point_labels is None:
+            return None
         if isinstance(point_labels, list):
             point_labels = np.array(point_labels, dtype=int)
         if point_labels.ndim != 1:

--- a/osam/types/_prompt_test.py
+++ b/osam/types/_prompt_test.py
@@ -1,0 +1,63 @@
+import json
+
+import numpy as np
+import pydantic
+import pytest
+
+from ._prompt import Prompt
+
+
+def test_model_dump_with_texts_only_serializes_none_points() -> None:
+    dumped = Prompt(texts=["dog"]).model_dump()
+    assert dumped["points"] is None
+    assert dumped["point_labels"] is None
+    assert dumped["texts"] == ["dog"]
+
+
+def test_model_dump_json_with_texts_only_serializes_null_points() -> None:
+    dumped = json.loads(Prompt(texts=["dog"]).model_dump_json())
+    assert dumped["points"] is None
+    assert dumped["point_labels"] is None
+
+
+def test_model_dump_serializes_points_and_labels_as_lists() -> None:
+    dumped = Prompt(
+        points=np.array([[1.0, 2.0]]), point_labels=np.array([1])
+    ).model_dump()
+    assert dumped["points"] == [[1.0, 2.0]]
+    assert dumped["point_labels"] == [1]
+
+
+def test_texts_only_roundtrips_through_model_dump() -> None:
+    src = Prompt(texts=["dog"])
+    restored = Prompt.model_validate(src.model_dump())
+    assert restored.texts == ["dog"]
+    assert restored.points is None
+    assert restored.point_labels is None
+
+
+def test_texts_only_roundtrips_through_model_dump_json() -> None:
+    src = Prompt(texts=["dog"])
+    restored = Prompt.model_validate_json(src.model_dump_json())
+    assert restored.texts == ["dog"]
+    assert restored.points is None
+    assert restored.point_labels is None
+
+
+def test_points_roundtrip_through_model_dump() -> None:
+    prompt = Prompt(
+        points=np.array([[1.0, 2.0], [3.0, 4.0]]), point_labels=np.array([1, 0])
+    )
+    restored = Prompt.model_validate(prompt.model_dump())
+    np.testing.assert_array_equal(restored.points, prompt.points)
+    np.testing.assert_array_equal(restored.point_labels, prompt.point_labels)
+
+
+def test_points_without_point_labels_is_rejected() -> None:
+    with pytest.raises(pydantic.ValidationError):
+        Prompt(points=np.array([[1.0, 2.0]]))
+
+
+def test_point_labels_outside_allowed_set_is_rejected() -> None:
+    with pytest.raises(pydantic.ValidationError):
+        Prompt(points=np.array([[1.0, 2.0]]), point_labels=np.array([7]))


### PR DESCRIPTION
`Prompt.points` and `Prompt.point_labels` are `Optional`, but their field
serializers called `.tolist()` and their `mode="before"` validators called
`.ndim` without a `None` guard. A texts-only `Prompt` (the YOLO-World and SAM3
path) therefore crashed:

```python
>>> Prompt(texts=["dog"]).model_dump()
PydanticSerializationError: ... 'NoneType' object has no attribute 'tolist'
>>> Prompt.model_validate(Prompt(texts=["dog"]).model_dump())
AttributeError: 'NoneType' object has no attribute 'ndim'
```

The crash hit both the serialize path (`model_dump` / `model_dump_json`) and,
symmetrically, the deserialize path. This guards `None` in both serializers and
both validators, mirroring the existing `Annotation.serialize_mask`.

## Test plan
- [x] Added `osam/types/_prompt_test.py`: texts-only and points round-trips
      through both dict and JSON, plus the core validation rules
- [x] `make lint` (ruff, ty)
- [x] `pytest osam/` — 26 passed
