### PR TITLE
test: add tests for _humanize

### DIFF
--- a/osam/_humanize.py
+++ b/osam/_humanize.py
@@ -14,9 +14,10 @@ def naturalsize(size: int) -> str:
     return f"{size:.2f} {prefix}"
 
 
-def naturaltime(dt: datetime.datetime) -> str:
+def naturaltime(dt: datetime.datetime, now: datetime.datetime | None = None) -> str:
     """Convert datetime to human readable format."""
-    now = datetime.datetime.now()
+    if now is None:
+        now = datetime.datetime.now()
     delta = now - dt
     if delta.days > 0:
         return f"{delta.days} days ago"

--- a/osam/_humanize_test.py
+++ b/osam/_humanize_test.py
@@ -1,0 +1,48 @@
+import datetime
+
+import pytest
+
+from ._humanize import naturalsize
+from ._humanize import naturaltime
+
+
+@pytest.mark.parametrize(
+    "size, expected",
+    [
+        (0, "0B"),
+        (1, "1.00 B"),
+        (1023, "1023.00 B"),
+        (1024, "1.00 KB"),
+        (1536, "1.50 KB"),
+        (1024**2, "1.00 MB"),
+        (1024**3, "1.00 GB"),
+        (1024**4, "1.00 TB"),
+        (1024**5, "1.00 PB"),
+    ],
+)
+def test_naturalsize(size: int, expected: str) -> None:
+    assert naturalsize(size) == expected
+
+
+@pytest.mark.parametrize(
+    "delta, expected",
+    [
+        (datetime.timedelta(days=2), "2 days ago"),
+        (datetime.timedelta(hours=23), "23 hours ago"),
+        (datetime.timedelta(hours=2), "2 hours ago"),
+        (datetime.timedelta(seconds=3599), "59 minutes ago"),
+        (datetime.timedelta(minutes=5), "5 minutes ago"),
+        (datetime.timedelta(seconds=120), "2 minutes ago"),
+        (datetime.timedelta(seconds=59), "59 seconds ago"),
+        (datetime.timedelta(seconds=10), "10 seconds ago"),
+        (datetime.timedelta(seconds=0), "0 seconds ago"),
+    ],
+)
+def test_naturaltime(delta: datetime.timedelta, expected: str) -> None:
+    now = datetime.datetime(2024, 1, 10, 12, 0, 0)
+    assert naturaltime(now - delta, now=now) == expected
+
+
+def test_naturaltime_default_now() -> None:
+    dt = datetime.datetime.now() - datetime.timedelta(seconds=5)
+    assert naturaltime(dt) == "5 seconds ago"


### PR DESCRIPTION
`_humanize.naturalsize` / `naturaltime` format the SIZE and MODIFIED columns of
the CLI `list` output but had no test coverage. This adds `_humanize_test.py`:
`naturalsize` is pinned across the B..PB range, and `naturaltime` across every
branch and both sides of each boundary.

`naturaltime` read `datetime.now()` internally, so exact-time assertions would be
non-deterministic. It now takes an optional `now` parameter (default behavior
unchanged) so the tests inject a fixed clock and assert exact strings.

## Test plan
- [x] Added `osam/_humanize_test.py` (18 cases)
- [x] `make lint` (ruff, ty)
- [x] `pytest osam/` — 36 passed
