### PR TITLE
feat: add OSAM_BLOB_ENDPOINT for mirror downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,24 @@ Here are models that can be downloaded:
 
 PS. `sam`, `efficientsam` is equivalent to `sam:latest`, `efficientsam:latest`.
 
+### Custom download endpoint
+
+Models are downloaded from their canonical URLs by default. To download from a
+mirror instead (for example, in networks where the canonical hosts are blocked),
+set `OSAM_BLOB_ENDPOINT` to a comma-separated list of endpoints tried in order:
+
+```bash
+# Try the mirror first, then fall back to the canonical host.
+export OSAM_BLOB_ENDPOINT="https://mirror.example.com,direct"
+```
+
+Each blob is fetched from `<endpoint>/<sha256-hex>`; the reserved value `direct`
+uses the model's canonical URL. Downloads are verified by SHA-256 regardless of
+the endpoint, so a mirror cannot serve corrupted data. When unset, only `direct`
+is used. Omit `direct` from the list (for example
+`OSAM_BLOB_ENDPOINT="https://mirror.example.com"`) to disable the canonical
+fallback and serve every blob from the mirror only.
+
 ## Usage
 
 ### CLI

--- a/docs/adr/0001-blob-download-endpoint-override.md
+++ b/docs/adr/0001-blob-download-endpoint-override.md
@@ -1,0 +1,30 @@
+# Blob download endpoint override
+
+osam downloads each model blob from a content-addressed, SHA-256-verified URL. We
+added `OSAM_BLOB_ENDPOINT`, an ordered comma-separated list of endpoints (with the
+reserved keyword `direct` for the canonical URL) that `Blob.pull` tries in turn,
+fetching each blob from `<endpoint>/<sha256-hex>`.
+
+## Context
+
+Some networks block the canonical model hosts (GitHub release assets, Hugging
+Face). Consumers that redistribute osam needed a way to point downloads at a
+reachable mirror without forking osam or rewriting URLs at runtime.
+
+## Considered options
+
+- **Monkey-patch `Blob.pull` downstream** to rewrite URLs. Rejected: couples
+  callers to a private method and breaks on internal refactors.
+- **Single mirror URL env var.** Rejected: no graceful fallback when the mirror
+  is incomplete or down.
+- **Ordered endpoint list with `direct` fallback (chosen).** Mirrors the
+  `GOPROXY` / `pip --index-url` idiom; one knob expresses mirror-only,
+  mirror-first, and origin-only.
+
+## Consequences
+
+- Mirrors are keyed by SHA-256 hex; a mirror need only host blobs under their
+  digest. Integrity is still enforced by the existing hash check, so a mirror
+  cannot serve corrupted data.
+- Unset behaviour is unchanged (`direct` only), so existing installs are
+  unaffected.

--- a/osam/types/_blob.py
+++ b/osam/types/_blob.py
@@ -5,9 +5,26 @@ import os
 import shutil
 import urllib.parse
 from collections.abc import Callable
+from typing import Final
 
 import gdown
 from loguru import logger
+
+_BLOB_ENDPOINT_ENV: Final = "OSAM_BLOB_ENDPOINT"
+_DIRECT: Final = "direct"
+
+
+def _resolve_endpoints() -> list[str]:
+    raw = os.environ.get(_BLOB_ENDPOINT_ENV, "")
+    endpoints = [entry.strip() for entry in raw.split(",") if entry.strip()]
+    return endpoints or [_DIRECT]
+
+
+def _build_endpoint_url(endpoint: str, url: str, hash: str) -> str:
+    if endpoint == _DIRECT:
+        return url
+    digest = hash.split(":", maxsplit=1)[-1]
+    return f"{endpoint.rstrip('/')}/{digest}"
 
 
 @dataclasses.dataclass
@@ -73,13 +90,42 @@ class Blob:
                 filename, bytes_so_far, bytes_total
             )
 
+        endpoints = _resolve_endpoints()
+
         def _download(url: str, path: str, hash: str, filename: str) -> None:
-            gdown.cached_download(
-                url=url,
-                path=path,
-                hash=hash,
-                progress=_gdown_progress(filename),
+            gdown_progress = _gdown_progress(filename)
+            errors: list[str] = []
+            last_error: Exception | None = None
+            for endpoint in endpoints:
+                source = _build_endpoint_url(endpoint=endpoint, url=url, hash=hash)
+                try:
+                    gdown.cached_download(
+                        url=source,
+                        path=path,
+                        hash=hash,
+                        progress=gdown_progress,
+                    )
+                    return
+                except Exception as e:
+                    last_error = e
+                    reason = " ".join(str(e).split())
+                    logger.warning(
+                        "Failed to download {!r} from {!r}: {}",
+                        filename,
+                        source,
+                        reason,
+                    )
+                    errors.append(f"{source}: {reason}")
+            message = (
+                f"Failed to download {filename!r} from all endpoints: "
+                f"{'; '.join(errors)}."
             )
+            if os.environ.get(_BLOB_ENDPOINT_ENV) and _DIRECT not in endpoints:
+                message += (
+                    f" Add {_DIRECT!r} to {_BLOB_ENDPOINT_ENV} to fall back to "
+                    f"the canonical URL."
+                )
+            raise RuntimeError(message) from last_error
 
         if self.attachments:
             blob_dir: str = os.path.dirname(self.path)
@@ -87,28 +133,22 @@ class Blob:
                 logger.warning("Removing file {!r} to create blob directory", blob_dir)
                 os.remove(blob_dir)
             os.makedirs(blob_dir, exist_ok=True)
-            _download(
-                url=self.url,
-                path=self.path,
-                hash=self.hash,
-                filename=self.filename,
+
+        _download(
+            url=self.url,
+            path=self.path,
+            hash=self.hash,
+            filename=self.filename,
+        )
+        for attachment in self.attachments:
+            attachment_path: str = os.path.join(
+                os.path.dirname(self.path), attachment.filename
             )
-            for attachment in self.attachments:
-                attachment_path: str = os.path.join(
-                    os.path.dirname(self.path), attachment.filename
-                )
-                _download(
-                    url=attachment.url,
-                    path=attachment_path,
-                    hash=attachment.hash,
-                    filename=attachment.filename,
-                )
-        else:
             _download(
-                url=self.url,
-                path=self.path,
-                hash=self.hash,
-                filename=self.filename,
+                url=attachment.url,
+                path=attachment_path,
+                hash=attachment.hash,
+                filename=attachment.filename,
             )
 
     def remove(self):

--- a/osam/types/_blob_test.py
+++ b/osam/types/_blob_test.py
@@ -1,6 +1,12 @@
 import os
+import pathlib
+from unittest import mock
+
+import pytest
 
 from ._blob import Blob
+from ._blob import _build_endpoint_url
+from ._blob import _resolve_endpoints
 
 
 def test_path_standalone_has_no_colon() -> None:
@@ -25,3 +31,162 @@ def test_path_with_attachments_has_no_colon() -> None:
         "sha256-4cacbb23c6903b1acf87f1d77ed806b840800c5fcd4ac8f650cbffed474b8896"
     )
     assert os.path.basename(blob.path) == "model.onnx"
+
+
+def test_resolve_endpoints_unset_is_direct(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OSAM_BLOB_ENDPOINT", raising=False)
+    assert _resolve_endpoints() == ["direct"]
+
+
+def test_resolve_endpoints_blank_is_direct(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OSAM_BLOB_ENDPOINT", "  ,  ")
+    assert _resolve_endpoints() == ["direct"]
+
+
+def test_resolve_endpoints_keeps_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OSAM_BLOB_ENDPOINT", " https://mirror.example.com , direct ")
+    assert _resolve_endpoints() == ["https://mirror.example.com", "direct"]
+
+
+def test_build_endpoint_url_direct_returns_canonical() -> None:
+    assert (
+        _build_endpoint_url(
+            endpoint="direct",
+            url="https://example.com/model.onnx",
+            hash="sha256:abc123",
+        )
+        == "https://example.com/model.onnx"
+    )
+
+
+def test_build_endpoint_url_mirror_is_hash_keyed() -> None:
+    assert (
+        _build_endpoint_url(
+            endpoint="https://mirror.example.com/",
+            url="https://example.com/model.onnx",
+            hash="sha256:abc123",
+        )
+        == "https://mirror.example.com/abc123"
+    )
+
+
+def test_pull_falls_back_to_direct_when_mirror_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OSAM_BLOB_ENDPOINT", "https://mirror.example.com,direct")
+    blob = Blob(url="https://example.com/model.onnx", hash="sha256:abc123")
+
+    tried: list[str] = []
+
+    def fake_cached_download(
+        url: str, path: str, hash: str, progress: object = None
+    ) -> None:
+        tried.append(url)
+        if url.startswith("https://mirror.example.com"):
+            raise RuntimeError("blocked")
+
+    with mock.patch(
+        "osam.types._blob.gdown.cached_download", side_effect=fake_cached_download
+    ):
+        blob.pull()
+
+    assert tried == [
+        "https://mirror.example.com/abc123",
+        "https://example.com/model.onnx",
+    ]
+
+
+def test_pull_raises_when_all_endpoints_fail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OSAM_BLOB_ENDPOINT", "https://mirror.example.com,direct")
+    blob = Blob(url="https://example.com/model.onnx", hash="sha256:abc123")
+
+    error = AssertionError("File hash doesn't match:\nactual: x\nexpected: y")
+    with mock.patch("osam.types._blob.gdown.cached_download", side_effect=error):
+        with pytest.raises(RuntimeError) as excinfo:
+            blob.pull()
+
+    message = str(excinfo.value)
+    assert "all endpoints" in message
+    assert "[" not in message
+    assert "\n" not in message
+    assert (
+        "https://mirror.example.com/abc123: File hash doesn't match: actual: x "
+        "expected: y; https://example.com/model.onnx: File hash doesn't match: "
+        "actual: x expected: y" in message
+    )
+    # 'direct' is already in the list, so the message must not suggest adding it.
+    assert "OSAM_BLOB_ENDPOINT" not in message
+    # The original failure is preserved as the cause for debugging.
+    assert excinfo.value.__cause__ is error
+
+
+def test_pull_error_suggests_direct_when_mirror_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OSAM_BLOB_ENDPOINT", "https://mirror.example.com")
+    blob = Blob(url="https://example.com/model.onnx", hash="sha256:abc123")
+
+    with mock.patch(
+        "osam.types._blob.gdown.cached_download",
+        side_effect=RuntimeError("blocked"),
+    ):
+        with pytest.raises(RuntimeError) as excinfo:
+            blob.pull()
+
+    message = str(excinfo.value)
+    assert "OSAM_BLOB_ENDPOINT" in message
+    assert "direct" in message
+
+
+def test_pull_uses_mirror_without_contacting_canonical(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OSAM_BLOB_ENDPOINT", "https://mirror.example.com,direct")
+    blob = Blob(url="https://example.com/model.onnx", hash="sha256:abc123")
+
+    tried: list[str] = []
+
+    def fake_cached_download(
+        url: str, path: str, hash: str, progress: object = None
+    ) -> None:
+        tried.append(url)
+
+    with mock.patch(
+        "osam.types._blob.gdown.cached_download", side_effect=fake_cached_download
+    ):
+        blob.pull()
+
+    assert tried == ["https://mirror.example.com/abc123"]
+
+
+def test_pull_attachments_use_per_attachment_hash(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    # os.path.expanduser uses HOME on POSIX and USERPROFILE on Windows.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.setenv("OSAM_BLOB_ENDPOINT", "https://mirror.example.com")
+    blob = Blob(
+        url="https://example.com/model.onnx",
+        hash="sha256:main",
+        attachments=[Blob(url="https://example.com/extra.bin", hash="sha256:extra")],
+    )
+
+    tried: list[str] = []
+
+    def fake_cached_download(
+        url: str, path: str, hash: str, progress: object = None
+    ) -> None:
+        tried.append(url)
+
+    with mock.patch(
+        "osam.types._blob.gdown.cached_download", side_effect=fake_cached_download
+    ):
+        blob.pull()
+
+    assert tried == [
+        "https://mirror.example.com/main",
+        "https://mirror.example.com/extra",
+    ]


### PR DESCRIPTION
## Summary
- Add `OSAM_BLOB_ENDPOINT`: an ordered, comma-separated list of download endpoints `Blob.pull` tries in turn, with the reserved keyword `direct` for the canonical URL.
- Each blob is fetched from `<endpoint>/<sha256-hex>`; any download or hash-verification failure falls through to the next endpoint. When every endpoint fails, the raised error chains the underlying cause and, only when actionable (a custom endpoint set without `direct`), suggests adding `direct`.
- SHA-256 verification is unchanged, so a mirror cannot serve corrupted data. Unset behaviour is exactly `direct`, so existing installs are unaffected.
- Lets redistributors point downloads at a reachable mirror (e.g. where GitHub / Hugging Face are blocked) without forking osam or rewriting URLs at runtime. Models the `GOPROXY` / `pip --index-url` idiom.

## Test plan
- [x] tests added in `osam/types/_blob_test.py`: endpoint resolution (unset / blank / ordered), hash-keyed URL building, mirror-first fallback, mirror-only success does not contact the canonical URL, per-attachment hash keying, and all-endpoints-fail (chained cause + actionable hint)
- [x] `uv run ruff format --check` + `uv run ruff check`
- [x] `uv run ty check`
- [x] `uv run pytest osam/types/_blob_test.py` — 12 passed
