### PR TITLE
chore: scaffold agent skills config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked in GitHub Issues (`gh` CLI) for `wkentaro/osam`; external PRs are also a triage surface. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical triage roles use their default label strings (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout: one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -53,19 +53,19 @@ osam run yoloworld --image <image_file>
 
 Here are models that can be downloaded:
 
-| Model | Parameters | Size | Download |
-|-------------------|------------|-------|------------------------------|
-| SAM 100M | 94M | 100MB | `osam run sam:100m` |
-| SAM 300M | 313M | 310MB | `osam run sam:300m` |
-| SAM 600M | 642M | 630MB | `osam run sam` |
-| SAM2 Tiny | 39M | 150MB | `osam run sam2:tiny` |
-| SAM2 Small | 46M | 170MB | `osam run sam2:small` |
-| SAM2 BasePlus | 82M | 300MB | `osam run sam2` |
-| SAM2 Large | 227M | 870MB | `osam run sam2:large` |
-| SAM3 | 893M | 3.4GB | `osam run sam3` |
-| EfficientSAM 10M | 10M | 40MB | `osam run efficientsam:10m` |
-| EfficientSAM 30M | 26M | 100MB | `osam run efficientsam` |
-| YOLO-World XL | 168M | 640MB | `osam run yoloworld` |
+| Model            | Parameters | Size  | Download                    |
+| ---------------- | ---------- | ----- | --------------------------- |
+| SAM 100M         | 94M        | 100MB | `osam run sam:100m`         |
+| SAM 300M         | 313M       | 310MB | `osam run sam:300m`         |
+| SAM 600M         | 642M       | 630MB | `osam run sam`              |
+| SAM2 Tiny        | 39M        | 150MB | `osam run sam2:tiny`        |
+| SAM2 Small       | 46M        | 170MB | `osam run sam2:small`       |
+| SAM2 BasePlus    | 82M        | 300MB | `osam run sam2`             |
+| SAM2 Large       | 227M       | 870MB | `osam run sam2:large`       |
+| SAM3             | 893M       | 3.4GB | `osam run sam3`             |
+| EfficientSAM 10M | 10M        | 40MB  | `osam run efficientsam:10m` |
+| EfficientSAM 30M | 26M        | 100MB | `osam run efficientsam`     |
+| YOLO-World XL    | 168M       | 640MB | `osam run yoloworld`        |
 
 PS. `sam`, `efficientsam` is equivalent to `sam:latest`, `efficientsam:latest`.
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,36 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+This is a **single-context** repo: one `CONTEXT.md` + `docs/adr/` at the repo root.
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-example-decision.md
+│   └── 0002-another-decision.md
+└── osam/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,34 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: yes.** _(Set to `no` if this repo should not treat external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dev = [
   "yamlfix>=1.19.1",
   "typos>=1.45.1",
   "pytest-cov>=7.1.0",
+  "mdformat-gfm>=1.0.0",
 ]
 
 [tool.hatch.metadata]

--- a/uv.lock
+++ b/uv.lock
@@ -879,6 +879,33 @@ wheels = [
 ]
 
 [[package]]
+name = "mdformat-gfm"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "mdformat" },
+    { name = "mdit-py-plugins" },
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/6f/a626ebb142a290474401b67e2d61e73ce096bf7798ee22dfe6270f924b3f/mdformat_gfm-1.0.0.tar.gz", hash = "sha256:d1d49a409a6acb774ce7635c72d69178df7dce1dc8cdd10e19f78e8e57b72623", size = 10112, upload-time = "2025-10-16T09:12:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/18/6bc2189b744dd383cad03764f41f30352b1278d2205096f77a29c0b327ad/mdformat_gfm-1.0.0-py3-none-any.whl", hash = "sha256:7305a50efd2a140d7c83505b58e3ac5df2b09e293f9bbe72f6c7bee8c678b005", size = 10970, upload-time = "2025-10-16T09:12:21.276Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1332,6 +1359,7 @@ dev = [
     { name = "ipython", version = "8.38.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "ipython", version = "9.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "mdformat" },
+    { name = "mdformat-gfm" },
     { name = "mypy" },
     { name = "onnx" },
     { name = "pytest" },
@@ -1364,6 +1392,7 @@ provides-extras = ["serve"]
 dev = [
     { name = "ipython", specifier = ">=8.38.0" },
     { name = "mdformat", specifier = ">=1.0.0" },
+    { name = "mdformat-gfm", specifier = ">=1.0.0" },
     { name = "mypy", specifier = ">=1.15.0" },
     { name = "onnx", specifier = ">=1.17.0" },
     { name = "pytest", specifier = ">=8.3.4" },


### PR DESCRIPTION
Scaffolds the per-repo configuration the engineering skills (`process-issues`, `triage`, `implement-issues`, `process-prs`, `brooks-*`, `diagnose`, `tdd`) expect, so they read this repo's conventions instead of guessing.

- `docs/agents/issue-tracker.md` — issues live in GitHub Issues (`gh` CLI); external PRs are also a triage surface
- `docs/agents/triage-labels.md` — the five canonical triage roles, mapped to their default label strings
- `docs/agents/domain.md` — single-context layout (`CONTEXT.md` + `docs/adr/` at the repo root)
- `AGENTS.md` — top-level `## Agent skills` block pointing at the three docs; `CLAUDE.md` is a symlink to it so both conventions read one source

The matching GitHub labels were created separately on the repo.
