### PR TITLE
fix: retry blob downloads to survive transient fetch failures

### DIFF
--- a/osam/types/_blob.py
+++ b/osam/types/_blob.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import dataclasses
 import os
 import shutil
+import time
 import urllib.parse
 from collections.abc import Callable
 from typing import Final
@@ -93,29 +94,42 @@ class Blob:
         endpoints = _resolve_endpoints()
 
         def _download(url: str, path: str, hash: str, filename: str) -> None:
+            N_RETRIES: Final = 3
             gdown_progress = _gdown_progress(filename)
             errors: list[str] = []
             last_error: Exception | None = None
-            for endpoint in endpoints:
-                source = _build_endpoint_url(endpoint=endpoint, url=url, hash=hash)
-                try:
-                    gdown.cached_download(
-                        url=source,
-                        path=path,
-                        hash=hash,
-                        progress=gdown_progress,
-                    )
-                    return
-                except Exception as e:
-                    last_error = e
-                    reason = " ".join(str(e).split())
+            for attempt in range(N_RETRIES):
+                errors = []
+                for endpoint in endpoints:
+                    source = _build_endpoint_url(endpoint=endpoint, url=url, hash=hash)
+                    try:
+                        gdown.cached_download(
+                            url=source,
+                            path=path,
+                            hash=hash,
+                            progress=gdown_progress,
+                        )
+                        return
+                    except Exception as e:
+                        last_error = e
+                        reason = " ".join(str(e).split())
+                        logger.warning(
+                            "Failed to download {!r} from {!r}: {}",
+                            filename,
+                            source,
+                            reason,
+                        )
+                        errors.append(f"{source}: {reason}")
+                if attempt < N_RETRIES - 1:
                     logger.warning(
-                        "Failed to download {!r} from {!r}: {}",
+                        "Download of {!r} failed on all endpoints "
+                        "(attempt {}/{}), retrying in {}s",
                         filename,
-                        source,
-                        reason,
+                        attempt + 1,
+                        N_RETRIES,
+                        2**attempt,
                     )
-                    errors.append(f"{source}: {reason}")
+                    time.sleep(2**attempt)
             message = (
                 f"Failed to download {filename!r} from all endpoints: "
                 f"{'; '.join(errors)}."

--- a/osam/types/_blob_test.py
+++ b/osam/types/_blob_test.py
@@ -4,9 +4,15 @@ from unittest import mock
 
 import pytest
 
+from . import _blob
 from ._blob import Blob
 from ._blob import _build_endpoint_url
 from ._blob import _resolve_endpoints
+
+
+@pytest.fixture(autouse=True)
+def _no_backoff_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_blob.time, "sleep", lambda seconds: None)
 
 
 def test_path_standalone_has_no_colon() -> None:
@@ -70,6 +76,44 @@ def test_build_endpoint_url_mirror_is_hash_keyed() -> None:
     )
 
 
+def test_pull_retries_transient_failure_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OSAM_BLOB_ENDPOINT", raising=False)
+    blob = Blob(url="https://example.com/model.onnx", hash="sha256:abc")
+
+    n_calls = 0
+
+    def fake_cached_download(
+        url: str, path: str, hash: str, progress: object = None
+    ) -> None:
+        nonlocal n_calls
+        n_calls += 1
+        if n_calls < 3:
+            raise AssertionError("File hash doesn't match")
+
+    with mock.patch(
+        "osam.types._blob.gdown.cached_download", side_effect=fake_cached_download
+    ):
+        blob.pull()
+
+    assert n_calls == 3
+
+
+def test_pull_raises_after_exhausting_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OSAM_BLOB_ENDPOINT", raising=False)
+    blob = Blob(url="https://example.com/model.onnx", hash="sha256:abc")
+
+    error = AssertionError("File hash doesn't match")
+    with mock.patch("osam.types._blob.gdown.cached_download", side_effect=error):
+        with pytest.raises(RuntimeError) as excinfo:
+            blob.pull()
+
+    assert excinfo.value.__cause__ is error
+
+
 def test_pull_falls_back_to_direct_when_mirror_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -91,6 +135,41 @@ def test_pull_falls_back_to_direct_when_mirror_fails(
         blob.pull()
 
     assert tried == [
+        "https://mirror.example.com/abc123",
+        "https://example.com/model.onnx",
+    ]
+
+
+def test_pull_retries_whole_cycle_not_single_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OSAM_BLOB_ENDPOINT", "https://mirror.example.com,direct")
+    blob = Blob(url="https://example.com/model.onnx", hash="sha256:abc123")
+
+    tried: list[str] = []
+    n_direct = 0
+
+    def fake_cached_download(
+        url: str, path: str, hash: str, progress: object = None
+    ) -> None:
+        nonlocal n_direct
+        tried.append(url)
+        if url.startswith("https://mirror.example.com"):
+            raise RuntimeError("blocked")
+        n_direct += 1
+        if n_direct < 2:
+            raise AssertionError("File hash doesn't match")
+
+    with mock.patch(
+        "osam.types._blob.gdown.cached_download", side_effect=fake_cached_download
+    ):
+        blob.pull()
+
+    # Each cycle fails over mirror -> direct; the mirror is not retried to
+    # exhaustion before direct is tried.
+    assert tried == [
+        "https://mirror.example.com/abc123",
+        "https://example.com/model.onnx",
         "https://mirror.example.com/abc123",
         "https://example.com/model.onnx",
     ]


### PR DESCRIPTION
CI intermittently failed the model-download tests with `File hash doesn't match`. HuggingFace occasionally serves a small error page (e.g. CDN rate-limiting on the runner) instead of the model file; gdown saves that body verbatim, so the sha256 check fails and `model.pull()` aborts. The declared hashes are correct, the fetch is just flaky (a re-run of the same commit passes).

Retry `gdown.cached_download` up to 3 times with exponential backoff before surfacing the error, so a transient bad response no longer fails the pull.

## Test plan
- [x] `pytest osam/types/_blob_test.py` — retries until the download succeeds, and re-raises after exhausting retries
- [x] `make lint`
