### PR TITLE
fix: suppress gdown's tqdm when a progress callback is supplied

### DIFF
--- a/osam/types/_blob.py
+++ b/osam/types/_blob.py
@@ -108,6 +108,7 @@ class Blob:
                             path=path,
                             hash=hash,
                             progress=gdown_progress,
+                            quiet=gdown_progress is not None,
                         )
                         return
                     except Exception as e:

--- a/osam/types/_blob_test.py
+++ b/osam/types/_blob_test.py
@@ -85,7 +85,7 @@ def test_pull_retries_transient_failure_then_succeeds(
     n_calls = 0
 
     def fake_cached_download(
-        url: str, path: str, hash: str, progress: object = None
+        url: str, path: str, hash: str, progress: object = None, quiet: bool = False
     ) -> None:
         nonlocal n_calls
         n_calls += 1
@@ -123,7 +123,7 @@ def test_pull_falls_back_to_direct_when_mirror_fails(
     tried: list[str] = []
 
     def fake_cached_download(
-        url: str, path: str, hash: str, progress: object = None
+        url: str, path: str, hash: str, progress: object = None, quiet: bool = False
     ) -> None:
         tried.append(url)
         if url.startswith("https://mirror.example.com"):
@@ -150,7 +150,7 @@ def test_pull_retries_whole_cycle_not_single_endpoint(
     n_direct = 0
 
     def fake_cached_download(
-        url: str, path: str, hash: str, progress: object = None
+        url: str, path: str, hash: str, progress: object = None, quiet: bool = False
     ) -> None:
         nonlocal n_direct
         tried.append(url)
@@ -228,7 +228,7 @@ def test_pull_uses_mirror_without_contacting_canonical(
     tried: list[str] = []
 
     def fake_cached_download(
-        url: str, path: str, hash: str, progress: object = None
+        url: str, path: str, hash: str, progress: object = None, quiet: bool = False
     ) -> None:
         tried.append(url)
 
@@ -256,7 +256,7 @@ def test_pull_attachments_use_per_attachment_hash(
     tried: list[str] = []
 
     def fake_cached_download(
-        url: str, path: str, hash: str, progress: object = None
+        url: str, path: str, hash: str, progress: object = None, quiet: bool = False
     ) -> None:
         tried.append(url)
 
@@ -269,3 +269,25 @@ def test_pull_attachments_use_per_attachment_hash(
         "https://mirror.example.com/main",
         "https://mirror.example.com/extra",
     ]
+
+
+def test_pull_quiets_gdown_only_when_progress_given(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OSAM_BLOB_ENDPOINT", raising=False)
+    blob = Blob(url="https://example.com/model.onnx", hash="sha256:abc")
+
+    quiets: list[bool] = []
+
+    def fake_cached_download(
+        url: str, path: str, hash: str, progress: object = None, quiet: bool = False
+    ) -> None:
+        quiets.append(quiet)
+
+    with mock.patch(
+        "osam.types._blob.gdown.cached_download", side_effect=fake_cached_download
+    ):
+        blob.pull()
+        blob.pull(progress=lambda filename, bytes_so_far, bytes_total: None)
+
+    assert quiets == [False, True]


### PR DESCRIPTION
`Blob.pull()` passes a `progress` callback to `gdown.cached_download`, but gdown still writes its own tqdm bar to stderr. When a caller renders its own progress (labelme's Qt download dialog), that bar is redundant, and in windowed PyInstaller builds with no console, writing to a missing stderr is a known crash source (wkentaro/labelme#1300).

Pass `quiet=True` only when a `progress` callback is supplied, so the callback is the single source of progress. CLI pulls (no callback) keep gdown's bar, so `osam run sam3` still shows download progress.

## Test plan
- [x] `pytest osam/types/_blob_test.py` — added `test_pull_quiets_gdown_only_when_progress_given` asserting `quiet` is `False` without a callback and `True` with one
- [x] `make lint`

Closes #61
