### PR TITLE
ci: publish to PyPI on release published instead of tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,21 @@
 ---
 name: Publish to PyPI
 on:
-  push:
-    tags: [v*]
+  release:
+    types: [published]
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/osam
     permissions:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v7
       - run: uv build
       - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Switch PyPI publishing to fire on a GitHub Release (`release: published`)
instead of a raw tag push, and scope the publish job to a dedicated `pypi`
environment so trusted publishing is gated to that environment rather than any
successful workflow run. `fetch-depth: 0` is added so `hatch-vcs` can derive the
version from tags; `checkout`/`setup-uv` bumped to match.

The matching PyPI trusted-publisher (environment `pypi`) and the GitHub `pypi`
environment are already configured.

## Test plan
- [x] Workflow YAML parses; trigger/permissions unchanged in shape
- [ ] Next `v*` GitHub Release publishes to PyPI through the `pypi` environment
