### PR TITLE
ci: cache uv and model weights, cancel stale runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   setup:
     runs-on: ${{ matrix.os }}
@@ -16,6 +19,7 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
+          enable-cache: true
       - run: make setup
       - run: |
           uv build
@@ -32,6 +36,7 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
+          enable-cache: true
       - run: make setup
       - run: make lint
   test:
@@ -55,5 +60,12 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
+          enable-cache: true
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/osam/models/blobs
+          key: osam-models-${{ runner.os }}-${{ hashFiles('osam/_models/**') }}
+          restore-keys: |
+            osam-models-${{ runner.os }}-
       - run: make setup
       - run: make test PYTEST_ARGS="${{ matrix.pytest-args }}"


### PR DESCRIPTION
The test jobs re-download model weights on every run: `osam/conftest.py`
calls `model.pull()` for each registered model at session start, and the
ubuntu test job pulls the full model set (no `not extra` filter), so each
run fetches gigabytes from the network with zero reuse. Dependencies are
also re-resolved from scratch across all 19 jobs.

- Enable `setup-uv`'s built-in cache (`enable-cache: true`) on every job
- Cache the model blob dir (`~/.cache/osam/models/blobs`) on the test jobs,
  keyed on `osam/_models/**` so it invalidates when a model definition
  changes; `restore-keys` lets a changed key still seed from the last cache
  and re-download only what moved
- Add a `concurrency` group so a new push cancels in-progress runs

Test coverage is unchanged; this only affects caching and run scheduling.

## Test plan
- [x] `yamlfix --check .github/workflows/ci.yml` passes
- [ ] First run on this PR populates the caches; subsequent runs reuse them
