### PR TITLE
docs: fix HTTP curl example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ Image.fromarray(mask).save("mask.png")
 osam serve
 
 # POST request
-curl 127.0.0.1:11368/api/generate -X POST \
-  -H "Content-Type: application/json" \
-  -d "{\"model\": \"efficientsam\", \"image\": \"$(cat examples/_images/dogs.jpg | base64)\"}" \
-  | jq -r .mask | base64 --decode > mask.png
+base64 < examples/_images/dogs.jpg \
+  | jq -Rs '{model: "efficientsam", image: gsub("\n"; "")}' \
+  | curl 127.0.0.1:11368/api/generate -X POST --json @- \
+  | jq -r '.annotations[0].mask' | base64 --decode > mask.png
 ```


### PR DESCRIPTION
The HTTP example was broken in two ways. It inlined the base64 image into
argv via `-d "$(... | base64)"`, which overflows `ARG_MAX` and fails with
`zsh: argument list too long`. And it read the mask from a top-level
`.mask` field that no longer exists, so `jq -r .mask` emitted `null` and
`base64 --decode` wrote a 3-byte garbage `mask.png`.

The rewrite streams the base64 through stdin (`base64 | jq -Rs | curl --json @-`)
so nothing large hits argv, and reads the mask from its current location,
`.annotations[0].mask`.

## Test plan
- [x] Ran the new pipeline against a live `osam serve`; it writes a valid
      430x1033 grayscale PNG (`file mask.png` confirms).
