### PR TITLE
docs: lead README hero with demo and badge row

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,15 @@
   <p>
     Get up and running with promptable vision models locally.
   </p>
+  <p>
+    <a href="https://pypi.python.org/pypi/osam"><img src="https://img.shields.io/pypi/v/osam.svg"></a>
+    <a href="https://pypi.org/project/osam"><img src="https://img.shields.io/pypi/pyversions/osam.svg"></a>
+    <a href="https://github.com/wkentaro/osam/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/osam.svg"></a>
+  </p>
   <br>
-  <br>
-  <br>
+  <img src="assets/dogs_sam3.png" width="32%">
+  <img src="assets/dogs_sam2.png" width="32%">
+  <img src="assets/dogs_efficientsam.png" width="32%">
 </div>
 
 *Osam* (/oʊˈsɑm/) is a tool to run open-source promptable vision models locally
@@ -20,9 +26,6 @@
 ## Installation
 
 ### Pip
-
-<a href="https://pypi.org/project/osam"><img src="https://img.shields.io/pypi/pyversions/osam.svg"></a>
-<a href="https://pypi.python.org/pypi/osam"><img src="https://img.shields.io/pypi/v/osam.svg"></a>
 
 ```bash
 pip install osam


### PR DESCRIPTION
The hero centered a bare wordmark padded with three empty `<br>` spacers, while the segmentation outputs (the actual pitch for a vision tool) sat far down the page and the PyPI badges were buried inside the Installation section. This leads with the demo, consolidates badges into a hero row, and adds a license badge.

<img src="https://github.com/wkentaro/osam/raw/819fe50344ab9880d1eb6e4f5a797ce2993569e0/assets/dogs_sam3.png" width="32%"> <img src="https://github.com/wkentaro/osam/raw/819fe50344ab9880d1eb6e4f5a797ce2993569e0/assets/dogs_sam2.png" width="32%"> <img src="https://github.com/wkentaro/osam/raw/819fe50344ab9880d1eb6e4f5a797ce2993569e0/assets/dogs_efficientsam.png" width="32%">

## Test plan
- [x] `mdformat-gfm` reports README as formatted
- [x] hero/badge/license image paths resolve against `assets/`
