### PR TITLE
chore: remove unused src/ workspace dir

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,8 +87,6 @@ osam = "osam:__main__.cli"
 ignore_missing_imports = true
 
 [tool.ruff]
-exclude = [".conda", ".git", "src"]
-
 line-length = 88
 indent-width = 4
 

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,4 +1,0 @@
-/osam-core
-/osam-efficientsam
-/osam-sam
-/osam-yoloworld


### PR DESCRIPTION
The `src/` directory held local editable checkouts of the `osam-*` sibling
packages (`osam-core`, `osam-sam`, `osam-efficientsam`, `osam-yoloworld`) from
when osam was split across them. That split has since been folded back into the
single root `osam/` package, so nothing depends on, imports, or points into
`src/` anymore; the only tracked file was its `.gitignore`.

This also drops the now-dead `[tool.ruff] exclude` list. It only existed to skip
`src/` and a `.conda` dir we no longer use, and ruff's built-in defaults already
exclude `.git` (plus `.venv`, `build`, `dist`, etc.).

## Test plan
- [x] `uv run ruff check .` passes and still skips `.venv`/caches with no explicit `exclude`
- [x] package builds (`uv` editable install)
