### PR TITLE
feat: expose model license metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         include:
           - os: ubuntu-latest
             python-version: '3.10'
-            pytest-args: -n 3  # memory is insufficient to run in full parallel (4)
+            pytest-args: -n 2  # large models exceed runner memory with 3 workers
           - os: macos-latest
             python-version: '3.10'
             pytest-args: -n 4 -m 'not extra'    # minimum version by 'not extra'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `osam.apis.get_model_metadata` and `types.ModelMetadata` exposing each model's license name, SPDX identifier, license URL, and export source URL, all pinned to immutable revisions (#77).
+
+### Changed
+
+- SAM3 blobs download from a pinned Hugging Face revision instead of `main` (#77).
+
 ## [0.5.0] - 2026-06-30
 
 ### Added

--- a/osam/_models/efficientsam/_models.py
+++ b/osam/_models/efficientsam/_models.py
@@ -9,6 +9,13 @@ from . import _encoding
 
 
 class EfficientSam(SamBase):
+    metadata = types.ModelMetadata(
+        license_name="Apache License 2.0",
+        license_url="https://github.com/wkentaro/efficient-sam/blob/6aebcba09318c4dfe2f9560f7a3f8c42d8b01657/LICENSE",
+        source_url="https://github.com/wkentaro/efficient-sam/tree/6aebcba09318c4dfe2f9560f7a3f8c42d8b01657",
+        license_spdx="Apache-2.0",
+    )
+
     def encode_image(self, image: np.ndarray) -> types.ImageEmbedding:
         return _encoding.compute_image_embedding_from_image(
             encoder_session=self._inference_sessions["encoder"],

--- a/osam/_models/sam/_models.py
+++ b/osam/_models/sam/_models.py
@@ -12,6 +12,13 @@ from . import _encoding
 
 
 class SamBase(types.Model):
+    metadata = types.ModelMetadata(
+        license_name="Apache License 2.0",
+        license_url="https://github.com/wkentaro/segment-anything/blob/13b8480edd05cde9bcf29f9c8a6040b2abe8db56/LICENSE",
+        source_url="https://github.com/wkentaro/segment-anything/tree/13b8480edd05cde9bcf29f9c8a6040b2abe8db56",
+        license_spdx="Apache-2.0",
+    )
+
     @abc.abstractmethod
     def _generate_mask_from_image_embedding(
         self, image_embedding: types.ImageEmbedding, prompt: types.Prompt

--- a/osam/_models/sam2/_models.py
+++ b/osam/_models/sam2/_models.py
@@ -9,6 +9,13 @@ from . import _encoding
 
 
 class Sam2(SamBase):
+    metadata = types.ModelMetadata(
+        license_name="Apache License 2.0",
+        license_url="https://github.com/facebookresearch/sam2/blob/3a7889d905e38ca043c9b5a571ec1635bab678ac/LICENSE",
+        source_url="https://github.com/ryouchinsa/sam-cpp-macos/tree/d7399261aab3de35e01172e90da6da4e3191df4e",
+        license_spdx="Apache-2.0",
+    )
+
     def encode_image(self, image: npt.NDArray[np.uint8]) -> types.ImageEmbedding:
         return _encoding.compute_image_embedding_from_image(
             encoder_session=self._inference_sessions["encoder"], image=image

--- a/osam/_models/sam3/_models.py
+++ b/osam/_models/sam3/_models.py
@@ -12,30 +12,35 @@ from ..yoloworld.clip import tokenize
 
 class Sam3(types.Model):
     name = "sam3:latest"
+    metadata = types.ModelMetadata(
+        license_name="SAM License",
+        license_url="https://huggingface.co/wkentaro/sam3-onnx-models-v0.3.0/blob/895f3980b24a88249898cbe5a44571b15dec2a7f/LICENSE",
+        source_url="https://github.com/wkentaro/sam3-onnx/tree/8d9855a958127c6c1d2561c4b20ce3a3e1674387",
+    )
 
     _blobs = {
         "image_encoder": types.Blob(
-            url="https://huggingface.co/wkentaro/sam3-onnx-models-v0.3.0/resolve/main/sam3_image_encoder.onnx",
+            url="https://huggingface.co/wkentaro/sam3-onnx-models-v0.3.0/resolve/895f3980b24a88249898cbe5a44571b15dec2a7f/sam3_image_encoder.onnx",
             hash="sha256:c6f3769e9d42573806c34b663d6100b3827a4c0ecba6f45dbf39b8f3906be725",
             attachments=[
                 types.Blob(
-                    url="https://huggingface.co/wkentaro/sam3-onnx-models-v0.3.0/resolve/main/sam3_image_encoder.onnx.data",
+                    url="https://huggingface.co/wkentaro/sam3-onnx-models-v0.3.0/resolve/895f3980b24a88249898cbe5a44571b15dec2a7f/sam3_image_encoder.onnx.data",
                     hash="sha256:03bd50b0703e2b04e2193ca831b7f9d5ecf40bc5287cc59b1970f56ab800c995",
                 ),
             ],
         ),
         "language_encoder": types.Blob(
-            url="https://huggingface.co/wkentaro/sam3-onnx-models-v0.3.0/resolve/main/sam3_language_encoder.onnx",
+            url="https://huggingface.co/wkentaro/sam3-onnx-models-v0.3.0/resolve/895f3980b24a88249898cbe5a44571b15dec2a7f/sam3_language_encoder.onnx",
             hash="sha256:b3b465935c9bf4cf5efd950589741f3da5eec9e9bfe459576989cbe565331b53",
             attachments=[
                 types.Blob(
-                    url="https://huggingface.co/wkentaro/sam3-onnx-models-v0.3.0/resolve/main/sam3_language_encoder.onnx.data",
+                    url="https://huggingface.co/wkentaro/sam3-onnx-models-v0.3.0/resolve/895f3980b24a88249898cbe5a44571b15dec2a7f/sam3_language_encoder.onnx.data",
                     hash="sha256:1b03dabc657c1f2887d1b8ce2a3537467d4c033ea1f8c8be141fbca55e4b95f7",
                 ),
             ],
         ),
         "decoder": types.Blob(
-            url="https://huggingface.co/wkentaro/sam3-onnx-models-v0.3.0/resolve/main/sam3_decoder.onnx",
+            url="https://huggingface.co/wkentaro/sam3-onnx-models-v0.3.0/resolve/895f3980b24a88249898cbe5a44571b15dec2a7f/sam3_decoder.onnx",
             hash="sha256:bbc216dbf3de4742f692c2a0a0fd215ea8957956002a05f28150040a88b5dc1a",
         ),
     }

--- a/osam/_models/yoloworld/__init__.py
+++ b/osam/_models/yoloworld/__init__.py
@@ -11,6 +11,13 @@ from . import clip
 
 
 class _YoloWorld(types.Model):
+    metadata = types.ModelMetadata(
+        license_name="GNU General Public License v3.0",
+        license_url="https://github.com/wkentaro/yolo-world-onnx/blob/959674c1f64095e78ee3d9bb246d01f2443caf35/LICENSE",
+        source_url="https://github.com/wkentaro/yolo-world-onnx/blob/959674c1f64095e78ee3d9bb246d01f2443caf35/ARTIFACTS.md",
+        license_spdx="GPL-3.0-only",
+    )
+
     _input_size: int
 
     def generate(self, request: types.GenerateRequest) -> types.GenerateResponse:

--- a/osam/apis.py
+++ b/osam/apis.py
@@ -41,6 +41,10 @@ def get_model_type_by_name(name: str) -> Type[types.Model]:
     return cls
 
 
+def get_model_metadata(name: str) -> types.ModelMetadata:
+    return get_model_type_by_name(name=name).metadata
+
+
 def generate(request: types.GenerateRequest) -> types.GenerateResponse:
     global running_model
 

--- a/osam/apis_test.py
+++ b/osam/apis_test.py
@@ -1,4 +1,5 @@
 import pathlib
+import re
 
 import imgviz
 import numpy as np
@@ -126,3 +127,33 @@ def test_generate_box_to_mask_sam3(model: str) -> None:
         assert annotation.bounding_box is not None
         bb = annotation.bounding_box
         assert annotation.mask.shape == (bb.ymax - bb.ymin + 1, bb.xmax - bb.xmin + 1)
+
+
+def test_registered_models_have_immutable_license_metadata() -> None:
+    revision_pattern = re.compile(r"/(?:blob|tree)/[0-9a-f]{40}(?:/|$)")
+
+    for model_type in apis.registered_model_types:
+        metadata = apis.get_model_metadata(model_type.name)
+
+        assert metadata.license_name
+        assert metadata.license_url.startswith("https://")
+        assert metadata.source_url.startswith("https://")
+        assert revision_pattern.search(metadata.license_url)
+        assert revision_pattern.search(metadata.source_url)
+
+
+def test_yoloworld_metadata_points_to_artifact_provenance() -> None:
+    metadata = apis.get_model_metadata("yoloworld")
+
+    assert metadata.license_spdx == "GPL-3.0-only"
+    url_prefix = "https://github.com/wkentaro/yolo-world-onnx/blob/"
+    assert metadata.license_url.startswith(url_prefix)
+    assert metadata.license_url.endswith("/LICENSE")
+    assert metadata.source_url.startswith(url_prefix)
+    assert metadata.source_url.endswith("/ARTIFACTS.md")
+
+    license_revision = metadata.license_url.removeprefix(url_prefix).split("/", 1)[0]
+    source_revision = metadata.source_url.removeprefix(url_prefix).split("/", 1)[0]
+    assert license_revision == source_revision
+    assert len(source_revision) == 40
+    assert all(character in "0123456789abcdef" for character in source_revision)

--- a/osam/types/__init__.py
+++ b/osam/types/__init__.py
@@ -7,6 +7,7 @@ from ._generate import GenerateRequest  # noqa: F401
 from ._generate import GenerateResponse  # noqa: F401
 from ._image_embedding import ImageEmbedding  # noqa: F401
 from ._model import Model  # noqa: F401
+from ._model_metadata import ModelMetadata  # noqa: F401
 from ._prompt import Prompt  # noqa: F401
 
 

--- a/osam/types/_model.py
+++ b/osam/types/_model.py
@@ -15,10 +15,12 @@ from ._blob import Blob
 from ._generate import GenerateRequest
 from ._generate import GenerateResponse
 from ._image_embedding import ImageEmbedding
+from ._model_metadata import ModelMetadata
 
 
 class Model(abc.ABC):
     name: str
+    metadata: ModelMetadata
 
     _blobs: Dict[str, Blob]
     _inference_sessions: Dict[str, onnxruntime.InferenceSession]

--- a/osam/types/_model_metadata.py
+++ b/osam/types/_model_metadata.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ModelMetadata:
+    license_name: str
+    license_url: str
+    source_url: str
+    license_spdx: str | None = None


### PR DESCRIPTION
## Summary

- Expose model-specific license, SPDX, and source provenance through the public API so clients can present terms before downloading a model.
- Cover every registered model, while leaving SPDX unset for custom licenses that do not have an identifier.
- Point each model at immutable license and export-source revisions, and pin SAM3 downloads to its Hugging Face snapshot.
- Run the full Linux inference suite with two workers because three concurrent large models exceeded hosted-runner memory.

## Test plan

- [x] `uv run pytest -q --noconftest osam/apis_test.py -k "license_metadata or artifact_provenance"`
- [x] `make lint`
- [x] GitHub Actions: 19 checks passed
