### PR TITLE
docs: cut CHANGELOG section for v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-21
+
 ### Added
 
 - `osam.apis.get_model_metadata` and `types.ModelMetadata` exposing each model's license name, SPDX identifier, license URL, and export source URL, all pinned to immutable revisions (#77).
@@ -166,4 +168,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.4.0]: https://github.com/wkentaro/osam/compare/v0.3.1...v0.4.0
 [0.4.1]: https://github.com/wkentaro/osam/compare/v0.4.0...v0.4.1
 [0.5.0]: https://github.com/wkentaro/osam/compare/v0.4.1...v0.5.0
-[unreleased]: https://github.com/wkentaro/osam/compare/v0.5.0...HEAD
+[0.6.0]: https://github.com/wkentaro/osam/compare/v0.5.0...v0.6.0
+[unreleased]: https://github.com/wkentaro/osam/compare/v0.6.0...HEAD


### PR DESCRIPTION
Promote the `[Unreleased]` entries to a dated `[0.6.0]` section and advance the compare links, in preparation for tagging v0.6.0. Minor bump: adds model license and source metadata (#77) and pins SAM3 downloads to an immutable revision, with no breaking changes.

## Test plan

- [x] `uv run mdformat --check CHANGELOG.md`
