### PR TITLE
chore: drop ModelBase and ModelBlob deprecation shims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- `osam.types.ModelBase` and `osam.types.ModelBlob`, deprecated since July 2024; use `Model` and `Blob` (#80).
+
 ## [0.6.0] - 2026-08-21
 
 ### Added

--- a/osam/types/__init__.py
+++ b/osam/types/__init__.py
@@ -1,5 +1,3 @@
-import warnings
-
 from ._annotation import Annotation  # noqa: F401
 from ._blob import Blob  # noqa: F401
 from ._bounding_box import BoundingBox  # noqa: F401
@@ -9,19 +7,3 @@ from ._image_embedding import ImageEmbedding  # noqa: F401
 from ._model import Model  # noqa: F401
 from ._model_metadata import ModelMetadata  # noqa: F401
 from ._prompt import Prompt  # noqa: F401
-
-
-class ModelBase(Model):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        warnings.warn(
-            "This class is deprecated, use `Model` instead.", DeprecationWarning
-        )
-
-
-class ModelBlob(Blob):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        warnings.warn(
-            "This class is deprecated, use `Blob` instead.", DeprecationWarning
-        )


### PR DESCRIPTION
Deprecated in July 2024 (pre-0.2), six minor releases ago; well past the PEP 387 and NEP 23 minimum of two releases. labelme does not reference either name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKia9pzQpxHeHGvs4Qs8yC
