### PR TITLE
feat: add OSAM_ONNX_PROVIDERS to choose execution providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `OSAM_ONNX_PROVIDERS` to choose onnxruntime execution providers as a comma-separated list tried in order, for example CoreML or DirectML. Unset keeps the CUDA-or-CPU default (#82).
+
 ### Removed
 
 - `osam.types.ModelBase` and `osam.types.ModelBlob`, deprecated since July 2024; use `Model` and `Blob` (#80).

--- a/README.md
+++ b/README.md
@@ -89,6 +89,22 @@ is used. Omit `direct` from the list (for example
 `OSAM_BLOB_ENDPOINT="https://mirror.example.com"`) to disable the canonical
 fallback and serve every blob from the mirror only.
 
+### Execution providers
+
+Inference runs on `CUDAExecutionProvider` when the installed onnxruntime has it,
+otherwise on `CPUExecutionProvider`. To use another accelerator (CoreML on
+macOS, DirectML on Windows, TensorRT, ROCm), set `OSAM_ONNX_PROVIDERS` to a
+comma-separated list tried in the given order:
+
+```bash
+export OSAM_ONNX_PROVIDERS="CoreMLExecutionProvider,CPUExecutionProvider"
+```
+
+The provider package must be installed separately (for example
+`onnxruntime-gpu`, `onnxruntime-directml`, or `onnxruntime-silicon`). If a
+session cannot be created with the given list, osam logs the error and falls
+back to `CPUExecutionProvider`.
+
 ## Usage
 
 ### CLI

--- a/docs/adr/0002-onnx-providers-override.md
+++ b/docs/adr/0002-onnx-providers-override.md
@@ -1,0 +1,31 @@
+# ONNX execution provider override
+
+osam picks the onnxruntime execution providers for every model session in
+one place. We added `OSAM_ONNX_PROVIDERS`, a comma-separated ordered list, as
+the only way to change that choice. Unset keeps the existing behaviour: CUDA
+when available, else CPU.
+
+## Context
+
+Users on Apple Silicon, DirectML-capable Windows machines, and CUDA builds
+that reject one model's ops (#43, #76, #30) had no way to influence provider
+selection short of patching a private function.
+
+## Considered options
+
+- **Constructor or `generate` parameter.** Rejected: labelme and the CLI
+  both instantiate models with no arguments, so a parameter would not reach
+  the places that need it without widening every call site.
+- **Auto-probe platform accelerators (CoreML on macOS, DirectML on
+  Windows).** Deferred: onnxruntime falls back per node, which can be slower
+  than pure CPU, so a default needs per-model measurement first.
+- **Ordered env var (chosen).** Same idiom as `OSAM_BLOB_ENDPOINT`; one knob
+  expresses "prefer X, then Y" and is settable by an end user of any
+  downstream app.
+
+## Consequences
+
+- Session creation still falls back to CPU with a logged error when the
+  requested list fails, so a typo degrades performance rather than crashing.
+- Auto-probing can be added later behind the same resolver without changing
+  the interface.

--- a/osam/types/_model.py
+++ b/osam/types/_model.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import abc
 import hashlib
+import os
 from collections.abc import Callable
 from typing import Dict
+from typing import Final
 from typing import Optional
 from typing import Sequence
 
@@ -16,6 +18,18 @@ from ._generate import GenerateRequest
 from ._generate import GenerateResponse
 from ._image_embedding import ImageEmbedding
 from ._model_metadata import ModelMetadata
+
+_PROVIDERS_ENV: Final = "OSAM_ONNX_PROVIDERS"
+
+
+def resolve_providers() -> list[str]:
+    raw = os.environ.get(_PROVIDERS_ENV, "")
+    providers = [entry.strip() for entry in raw.split(",") if entry.strip()]
+    if providers:
+        return providers
+    if "CUDAExecutionProvider" in onnxruntime.get_available_providers():  # type: ignore[possibly-missing-attribute]
+        return ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    return ["CPUExecutionProvider"]
 
 
 class Model(abc.ABC):
@@ -97,12 +111,8 @@ def _load_inference_session(
     blob: Blob, providers: list[str] | None = None
 ) -> onnxruntime.InferenceSession:
     try:
-        # Try to use all of the available providers e.g., cuda, tensorrt.
         if providers is None:
-            if "CUDAExecutionProvider" in onnxruntime.get_available_providers():  # type: ignore[possibly-missing-attribute]
-                providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
-            else:
-                providers = ["CPUExecutionProvider"]
+            providers = resolve_providers()
         inference_session = onnxruntime.InferenceSession(blob.path, providers=providers)
     except Exception as e:
         # Even though there is fallback in onnxruntime, it won't always work.

--- a/osam/types/_model_test.py
+++ b/osam/types/_model_test.py
@@ -1,0 +1,22 @@
+import pytest
+
+from ._model import resolve_providers
+
+
+def test_resolve_providers_unset_ends_with_cpu(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OSAM_ONNX_PROVIDERS", raising=False)
+    assert resolve_providers()[-1] == "CPUExecutionProvider"
+
+
+def test_resolve_providers_env_keeps_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "OSAM_ONNX_PROVIDERS", " CoreMLExecutionProvider , CPUExecutionProvider "
+    )
+    assert resolve_providers() == ["CoreMLExecutionProvider", "CPUExecutionProvider"]
+
+
+def test_resolve_providers_blank_env_is_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OSAM_ONNX_PROVIDERS", " , ")
+    assert resolve_providers()[-1] == "CPUExecutionProvider"


### PR DESCRIPTION
Gives #76, #43 and #30 a knob without deciding the auto-probe question: `OSAM_ONNX_PROVIDERS="CoreMLExecutionProvider,CPUExecutionProvider"` works today on this Mac (efficientsam:10m runs on CoreML with the same bbox as CPU). Unset keeps the CUDA-or-CPU default.

Env var rather than a parameter because labelme and the CLI instantiate models with no arguments; recorded as ADR-0002.

A misspelled provider is not fatal: onnxruntime prints its own "EP Error … Falling back" and the existing CPU fallback in `_load_inference_session` still covers the case where session creation raises.

Refs #76, #43, #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKia9pzQpxHeHGvs4Qs8yC
